### PR TITLE
Bug:Payfee Redirect

### DIFF
--- a/frontend/src/pages/admin/fees/FeePayment.tsx
+++ b/frontend/src/pages/admin/fees/FeePayment.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useAppContext } from "../../../context/AppContext";
 
 const FeePayment: React.FC = () => {
@@ -9,6 +9,8 @@ const FeePayment: React.FC = () => {
   const [amount, setAmount] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [status, setStatus] = useState<"paid" | "pending">("pending");
+
+  const navigate = useNavigate();
 
   const student = students.find((s) => s.id === studentId);
   const feeStructure = feeStructures.find((fs) => fs.grade === student?.class);
@@ -32,6 +34,9 @@ const FeePayment: React.FC = () => {
     setAmount("");
     setDueDate("");
     setStatus("pending");
+
+    navigate(-1);
+
   };
 
   return (


### PR DESCRIPTION
### Pull Request Title: 
**Added redirect to previous page after payment fees are processed**

### Description:
- **What was changed**: 
  After the payment fees are successfully processed, the user is now redirected back to the previous page they were on.
  
- **Why this change was made**: 
  This change improves the user experience by ensuring that, after completing the payment process, the user is returned to their previous workflow or page, rather than being sent to a default page.

- **How it was implemented**:
  - Added logic to handle the redirection after the payment fees are processed.
  - Used `navigate(-1)` or equivalent to redirect the user.

### Related Issues:
- Issue #2


